### PR TITLE
Add bump task

### DIFF
--- a/lib/mix/tasks/bump.ex
+++ b/lib/mix/tasks/bump.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Bump do
 
   @spec run([binary]) :: :ok
   def run(args) do
-    check_main_branch()
+    check_master_branch()
     {parsed, _, _} = OptionParser.parse(args, strict: [level: :string])
     level = parsed[:level]
     version = Mix.Project.config()[:version]
@@ -34,13 +34,13 @@ defmodule Mix.Tasks.Bump do
     end
   end
 
-  defp check_main_branch() do
+  defp check_master_branch() do
     IO.puts("Checking current branch")
     current_branch = System.cmd("git", ["branch", "--show-current"])
 
     case current_branch do
-      {"main\n", _} -> {:ok, current_branch}
-      {_, _} -> raise "Not on main branch"
+      {"master\n", _} -> {:ok, current_branch}
+      {_, _} -> raise "Not on master branch"
     end
   end
 
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Bump do
 
   defp push_changes() do
     IO.puts("Pushing changes")
-    system("git push origin main")
+    system("git push origin master")
     {:ok, "Pushed changes"}
   end
 


### PR DESCRIPTION
## Summary

Adds a task which bumps the version number and adds a git tag.

To bump the package, run

```bash
mix bump --level major|minor|patch
```

This will:

- Update the mix.exs file
- Commit the changes to mix.exs
- Push the changes to main
- Create a new tag with the bumped version
- Push the tag