### PR TITLE
Fix OTP spelling

### DIFF
--- a/lib/exbox/metrics/connection.ex
+++ b/lib/exbox/metrics/connection.ex
@@ -2,5 +2,5 @@ defmodule Exbox.Metrics.Connection do
   @moduledoc """
   Connection for writing metrics to InfluxDB.
   """
-  use Instream.Connection, opt_app: :exbox
+  use Instream.Connection, otp_app: :exbox
 end


### PR DESCRIPTION
Configurations in `config.exe` map to the `otp_app` name, so the configurations do not go through when it can't find it.
This was slightly elusive due to the defaults being reasonable for local
Since we are in influxdb 1.6 in production we need to include a database with it or we get an exception and can't write our metrics. (More on this in follow up prs)