### PR TITLE
Handle exceptions to not detach telemetry

### DIFF
--- a/lib/exbox/metrics/client.ex
+++ b/lib/exbox/metrics/client.ex
@@ -23,7 +23,7 @@ defmodule Exbox.Metrics.Client do
       end
     rescue
       error ->
-        Logger.error("Failed to write metric to InfluxDB: #{inspect(error)}")
+        Logger.debug("Failed to write metric to InfluxDB: #{inspect(error)}")
     end
   end
 end

--- a/lib/exbox/metrics/metric_handler.ex
+++ b/lib/exbox/metrics/metric_handler.ex
@@ -40,7 +40,7 @@ defmodule Exbox.Metrics.MetricHandler do
       |> write_metric(config)
     rescue
       exception ->
-        Logger.error("Exception creating controller series: #{inspect(exception)}")
+        Logger.debug("Exception creating controller series: #{inspect(exception)}")
     end
   end
 


### PR DESCRIPTION
When we attach to telemetry events, if an exception occurs it detach's the handler from the event (rightly so, telemetry should not break your app). However that means that you need to restart your app to attach to the handler again

This handling is crude but it covers most cases. I will refine it more as I inspect issues. Though there will probably be a general rescue regardless.
There's a debate between catch and rescue but in elixir it doesn't make a big difference, though ideally in something like the instream connector I would rather hook into its failed state response.
