### PR TITLE
Move capture telemetry events flag further up

### DIFF
--- a/lib/exbox/metrics.ex
+++ b/lib/exbox/metrics.ex
@@ -50,12 +50,14 @@ defmodule Exbox.Metrics do
   """
   @spec attach_telemetry(binary(), list(atom())) :: :ok
   def attach_telemetry(event, params) do
-    :ok =
-      :telemetry.attach(
-        event,
-        params,
-        &MetricHandler.handle_event/4,
-        nil
-      )
+    if Application.get_env(:exbox, :capture_telemetry_events) do
+      :ok =
+        :telemetry.attach(
+          event,
+          params,
+          &MetricHandler.handle_event/4,
+          nil
+        )
+    end
   end
 end

--- a/lib/exbox/metrics/client.ex
+++ b/lib/exbox/metrics/client.ex
@@ -18,9 +18,7 @@ defmodule Exbox.Metrics.Client do
   @spec write_metric(series()) :: tuple()
   def write_metric(metric) do
     try do
-      if Application.get_env(:exbox, :capture_telemetry_events) do
-        Connection.write(metric)
-      end
+      Connection.write(metric)
     rescue
       error ->
         Logger.debug("Failed to write metric to InfluxDB: #{inspect(error)}")


### PR DESCRIPTION
Very minor change, there's not much point in attaching to events if we aren't going to be writing them.

Moved it up the pipeline to just reduce work
