### PR TITLE
Add workaround for OTP 26

### DIFF
--- a/lib/exbox/flags.ex
+++ b/lib/exbox/flags.ex
@@ -102,5 +102,10 @@ defmodule Zexbox.Flags do
     config
     |> Map.delete(:sdk_key)
     |> Map.update(:file_paths, [], fn paths -> Enum.map(paths, &String.to_charlist/1) end)
+    |> Map.merge(%{
+      http_options: %{
+        tls_options: :ldclient_config.tls_basic_options()
+      }
+    })
   end
 end


### PR DESCRIPTION
# Description
Adds a workaround for the LD client failing to start when using Elixir with OTP 26 as per [this issue](https://github.com/launchdarkly/erlang-server-sdk/issues/96).
