### PR TITLE
Add structured logs

### DIFF
--- a/lib/zexbox/logging/log_handler.ex
+++ b/lib/zexbox/logging/log_handler.ex
@@ -1,6 +1,8 @@
 defmodule Zexbox.Logging.LogHandler do
   @moduledoc """
-  Handles all log events. This uses the default Logger module to log events to the console.
+  Handles the default start and stop events for phoenix endpoints. This makes use of the
+  default [Logger](https://hexdocs.pm/logger/main/Logger.html) module and as such will obey the :logger configuration
+  specified in your app.
   """
   require Logger
 

--- a/lib/zexbox/logging/log_handler.ex
+++ b/lib/zexbox/logging/log_handler.ex
@@ -1,11 +1,11 @@
 defmodule Zexbox.Logging.LogHandler do
   @moduledoc """
-  Handles all log events.
+  Handles all log events. This uses the default Logger module to log events to the console.
   """
   require Logger
 
   @doc """
-  This function is called by the Phoenix endpoint when a controller action is started and finished.
+  This function is called by the Phoenix endpoint when a controller action is started or finished.
 
   ## Examples
 
@@ -15,16 +15,20 @@ defmodule Zexbox.Logging.LogHandler do
   """
   @spec handle_event(list(atom), map(), map(), map()) :: :ok
   def handle_event([:phoenix, :endpoint, :stop], measurements, metadata, config) do
-    Logger.log(
-      :info,
-      "LogHandler.handle_event/4 called with #{inspect(measurements)}, #{inspect(metadata)}, #{inspect(config)} on stop"
+    Logger.info(
+      event: [:phoenix, :endpoint, :stop],
+      measurements: measurements,
+      metadata: metadata,
+      config: config
     )
   end
 
   def handle_event([:phoenix, :endpoint, :start], measurements, metadata, config) do
-    Logger.log(
-      :info,
-      "LogHandler.handle_event/4 called with #{inspect(measurements)}, #{inspect(metadata)}, #{inspect(config)} on start"
+    Logger.info(
+      event: [:phoenix, :endpoint, :start],
+      measurements: measurements,
+      metadata: metadata,
+      config: config
     )
   end
 end

--- a/test/zexbox/logging/log_handler_test.exs
+++ b/test/zexbox/logging/log_handler_test.exs
@@ -13,7 +13,7 @@ defmodule Zexbox.Logging.LogHandlerTest do
                  %{bar: "foo"}
                )
              end) =~
-               "LogHandler.handle_event/4 called with %{foo: \"bar\"}, %{fizz: \"buzz\"}, %{bar: \"foo\"} on stop"
+               "[info] [event: [:phoenix, :endpoint, :stop], measurements: %{foo: \"bar\"}, metadata: %{fizz: \"buzz\"}, config: %{bar: \"foo\"}]"
     end
 
     test "returns :ok for start event" do
@@ -25,7 +25,7 @@ defmodule Zexbox.Logging.LogHandlerTest do
                  %{bar: "foo"}
                )
              end) =~
-               "LogHandler.handle_event/4 called with %{foo: \"bar\"}, %{fizz: \"buzz\"}, %{bar: \"foo\"} on start"
+               "[info] [event: [:phoenix, :endpoint, :start], measurements: %{foo: \"bar\"}, metadata: %{fizz: \"buzz\"}, config: %{bar: \"foo\"}]"
     end
   end
 end


### PR DESCRIPTION
# Description
Makes use of [structured data](https://hexdocs.pm/logger/main/Logger.html#module-message) in logs created by the `LogHandler` module. 
