### PR TITLE
Make sure to start link before attaching metrics

### DIFF
--- a/lib/zexbox/metrics.ex
+++ b/lib/zexbox/metrics.ex
@@ -47,8 +47,9 @@ defmodule Zexbox.Metrics do
   """
   @spec start_link(args :: any()) :: Supervisor.on_start()
   def start_link(_args) do
+    on_start = Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
     attach_controller_metrics()
-    Supervisor.start_link(__MODULE__, nil, name: __MODULE__)
+    on_start
   end
 
   defp attach_controller_metrics do


### PR DESCRIPTION
# Description
Metrics seemed to be getting logged intermittently (i.e. not consistently) and after a bit of investigation I believe it's due to the controller metrics telemtry being attached before the `Zexbox.Metrics` supervisor is started.
