### PR TITLE
Capture metrics errors so process doesn't crash

### DIFF
--- a/lib/zexbox/metrics/client.ex
+++ b/lib/zexbox/metrics/client.ex
@@ -79,5 +79,6 @@ defmodule Zexbox.Metrics.Client do
   rescue
     error ->
       Logger.debug("Failed to write metric to InfluxDB: #{inspect(error)}")
+      {:error, error.message}
   end
 end

--- a/lib/zexbox/metrics/client.ex
+++ b/lib/zexbox/metrics/client.ex
@@ -76,5 +76,8 @@ defmodule Zexbox.Metrics.Client do
 
   defp write_to_influx(metrics) do
     Connection.write(metrics)
+  rescue
+    error ->
+      Logger.debug("Failed to write metric to InfluxDB: #{inspect(error)}")
   end
 end

--- a/lib/zexbox/metrics/metric_handler.ex
+++ b/lib/zexbox/metrics/metric_handler.ex
@@ -21,50 +21,70 @@ defmodule Zexbox.Metrics.MetricHandler do
 
     %ControllerSeries{}
     |> ControllerSeries.tag(:method, metadata.conn.method)
-    |> ControllerSeries.tag(:action, action(metadata))
-    |> ControllerSeries.tag(:format, format(metadata))
     |> ControllerSeries.tag(:status, status)
-    |> ControllerSeries.tag(:controller, controller(metadata))
+    |> set_action_tag(metadata)
+    |> set_format_tag(metadata)
+    |> set_controller_tag(metadata)
     |> ControllerSeries.field(:count, 1)
-    |> ControllerSeries.field(:trace_id, trace_id(metadata))
     |> ControllerSeries.field(:success, success?(status))
     |> ControllerSeries.field(:path, metadata.conn.request_path)
-    |> ControllerSeries.field(:http_referer, referer(metadata.conn))
     |> ControllerSeries.field(:duration_ms, duration(measurements))
+    |> set_referer_field(metadata)
+    |> set_trace_id_field(metadata)
     |> write_metric(config)
   rescue
     exception ->
       Logger.debug("Exception creating controller series: #{inspect(exception)}")
   end
 
-  defp action(metadata) do
+  defp set_action_tag(series, metadata) do
     case metadata.conn[:private][:phoenix_action] do
-      nil -> nil
-      action -> Atom.to_string(action)
+      nil ->
+        series
+
+      action ->
+        ControllerSeries.tag(series, :action, Atom.to_string(action))
     end
   end
 
-  defp format(metadata) do
-    metadata.conn[:private][:phoenix_format]
+  defp set_format_tag(series, metadata) do
+    case metadata.conn[:private][:phoenix_format] do
+      nil ->
+        series
+
+      format ->
+        ControllerSeries.tag(series, :format, format)
+    end
   end
 
-  defp controller(metadata) do
+  defp set_controller_tag(series, metadata) do
     case metadata.conn[:private][:phoenix_controller] do
-      nil -> nil
-      controller -> Atom.to_string(controller)
+      nil ->
+        series
+
+      controller ->
+        ControllerSeries.tag(series, :controller, Atom.to_string(controller))
     end
   end
 
-  defp trace_id(metadata) do
-    metadata.conn.assigns[:trace_id]
+  defp set_trace_id_field(series, metadata) do
+    case metadata.conn[:assigns][:trace_id] do
+      nil ->
+        series
+
+      trace_id ->
+        ControllerSeries.field(series, :trace_id, trace_id)
+    end
   end
 
-  defp write_metric(metric, %{metric_client: client}) do
-    client.write_metric(metric)
-  end
+  defp set_referer_field(series, metadata) do
+    case Enum.find(metadata.conn.req_headers, fn {key, _value} -> key == "referer" end) do
+      nil ->
+        series
 
-  defp write_metric(metric, _config) do
-    Client.write_metric(metric)
+      {_key, value} ->
+        ControllerSeries.field(series, :http_referer, value)
+    end
   end
 
   defp duration(measurements) do
@@ -78,10 +98,11 @@ defmodule Zexbox.Metrics.MetricHandler do
     end
   end
 
-  defp referer(conn) do
-    case Enum.find(conn.req_headers, fn {key, _value} -> key == "referer" end) do
-      {_key, value} -> value
-      nil -> nil
-    end
+  defp write_metric(metric, %{metric_client: client}) do
+    client.write_metric(metric)
+  end
+
+  defp write_metric(metric, _config) do
+    Client.write_metric(metric)
   end
 end

--- a/test/zexbox/metrics/client_test.exs
+++ b/test/zexbox/metrics/client_test.exs
@@ -28,9 +28,9 @@ defmodule Zexbox.Metrics.ClientTest do
 
     test_with_mock "logs any errors that might occur while writing metrics", Connection,
       write: fn _metrics -> raise "Bork" end do
-      capture_log(fn ->
-        assert {:error, "Bork"} = Client.write_metric(@map)
-      end) =~ "Failed to write metric to InfluxDB: Bork"
+      assert capture_log(fn ->
+               assert {:error, "Bork"} = Client.write_metric(@map)
+             end) =~ "Failed to write metric to InfluxDB: %RuntimeError{message: \"Bork\"}"
     end
   end
 end

--- a/test/zexbox/metrics/client_test.exs
+++ b/test/zexbox/metrics/client_test.exs
@@ -1,5 +1,6 @@
 defmodule Zexbox.Metrics.ClientTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   import Mock
   alias Zexbox.Metrics.{Client, Connection, Series}
 
@@ -14,13 +15,22 @@ defmodule Zexbox.Metrics.ClientTest do
   }
 
   describe "write_metric/1" do
-    test_with_mock "when given a series", Connection, write: fn metrics -> {:ok, metrics} end do
+    test_with_mock "writes the metric when given a series", Connection,
+      write: fn metrics -> {:ok, metrics} end do
       series = struct(Series, @map)
       assert {:ok, @map} = Client.write_metric(series)
     end
 
-    test_with_mock "when given a map", Connection, write: fn metrics -> {:ok, metrics} end do
+    test_with_mock "writes the metric when given a map", Connection,
+      write: fn metrics -> {:ok, metrics} end do
       assert {:ok, @map} = Client.write_metric(@map)
+    end
+
+    test_with_mock "logs any errors that might occur while writing metrics", Connection,
+      write: fn _metrics -> raise "Bork" end do
+      capture_log(fn ->
+        assert {:error, "Bork"} = Client.write_metric(@map)
+      end) =~ "Failed to write metric to InfluxDB: Bork"
     end
   end
 end

--- a/test/zexbox/metrics/metric_handler_test.exs
+++ b/test/zexbox/metrics/metric_handler_test.exs
@@ -1,5 +1,6 @@
 defmodule Zexbox.Metrics.MetricHandlerTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   alias Zexbox.Metrics.{ControllerSeries, MetricHandler}
 
   defmodule MockClient do
@@ -9,52 +10,71 @@ defmodule Zexbox.Metrics.MetricHandlerTest do
     end
   end
 
-  test "handle_event/4" do
-    measurements = %{duration: 1_000_000_000}
+  describe "handle_event/4" do
+    setup do
+      event = [:phoenix, :endpoint, :stop]
 
-    metadata = %{
-      conn: %{
-        status: 200,
-        method: "GET",
-        private: %{
-          phoenix_action: :index,
-          phoenix_format: "html",
-          phoenix_controller: :page_controller
-        },
-        assigns: %{
-          trace_id: "trace_id"
-        },
-        request_path: "/",
-        req_headers: [{"referer", "https://www.google.com"}]
+      measurements = %{duration: 1_000_000_000}
+
+      metadata = %{
+        conn: %{
+          status: 200,
+          method: "GET",
+          private: %{
+            phoenix_action: :index,
+            phoenix_format: "html",
+            phoenix_controller: :page_controller
+          },
+          assigns: %{
+            trace_id: "trace_id"
+          },
+          request_path: "/",
+          req_headers: [{"referer", "https://www.google.com"}]
+        }
       }
-    }
 
-    config = %{metric_client: MockClient}
+      config = %{metric_client: MockClient}
 
-    expected = %ControllerSeries{
-      fields: %Zexbox.Metrics.ControllerSeries.Fields{
-        count: 1,
-        trace_id: "trace_id",
-        duration_ms: 1000,
-        http_referer: "https://www.google.com",
-        path: "/",
-        request_id: nil,
-        success: 1.0
-      },
-      tags: %Zexbox.Metrics.ControllerSeries.Tags{
-        action: "index",
-        controller: "page_controller",
-        format: "html",
-        method: "GET",
-        status: 200
-      }
-    }
+      {:ok, [event: event, measurements: measurements, metadata: metadata, config: config]}
+    end
 
-    assert MetricHandler.handle_event(
-             [:phoenix, :endpoint, :stop],
-             measurements,
-             metadata,
-             config
-           ) == expected
+    test "creates the expected ControllerSeries on success", %{
+      event: event,
+      measurements: measurements,
+      metadata: metadata,
+      config: config
+    } do
+      assert %ControllerSeries{
+               fields: %Zexbox.Metrics.ControllerSeries.Fields{
+                 count: 1,
+                 trace_id: "trace_id",
+                 duration_ms: 1000,
+                 http_referer: "https://www.google.com",
+                 path: "/",
+                 request_id: nil,
+                 success: 1.0
+               },
+               tags: %Zexbox.Metrics.ControllerSeries.Tags{
+                 action: "index",
+                 controller: "page_controller",
+                 format: "html",
+                 method: "GET",
+                 status: 200
+               }
+             } ==
+               MetricHandler.handle_event(
+                 event,
+                 measurements,
+                 metadata,
+                 config
+               )
+    end
+
+    test "captures and logs any exceptions", %{event: event} do
+      assert capture_log(fn ->
+               MetricHandler.handle_event(event, nil, nil, nil)
+             end) =~
+               "Exception creating controller series: %KeyError"
+    end
   end
 end

--- a/test/zexbox/metrics/metric_handler_test.exs
+++ b/test/zexbox/metrics/metric_handler_test.exs
@@ -45,7 +45,7 @@ defmodule Zexbox.Metrics.MetricHandlerTest do
       config: config
     } do
       assert %ControllerSeries{
-               fields: %Zexbox.Metrics.ControllerSeries.Fields{
+               fields: %ControllerSeries.Fields{
                  count: 1,
                  trace_id: "trace_id",
                  duration_ms: 1000,
@@ -54,13 +54,55 @@ defmodule Zexbox.Metrics.MetricHandlerTest do
                  request_id: nil,
                  success: 1.0
                },
-               tags: %Zexbox.Metrics.ControllerSeries.Tags{
+               tags: %ControllerSeries.Tags{
                  action: "index",
                  controller: "page_controller",
                  format: "html",
                  method: "GET",
                  status: 200
                }
+             } ==
+               MetricHandler.handle_event(
+                 event,
+                 measurements,
+                 metadata,
+                 config
+               )
+    end
+
+    test "conditionally adds tags and fields based on their presence", %{
+      event: event,
+      measurements: measurements,
+      config: config
+    } do
+      metadata = %{
+        conn: %{
+          status: 200,
+          method: "GET",
+          private: %{},
+          request_path: "/",
+          req_headers: []
+        }
+      }
+
+      assert %ControllerSeries{
+               fields: %ControllerSeries.Fields{
+                 count: 1,
+                 duration_ms: 1000,
+                 http_referer: nil,
+                 path: "/",
+                 request_id: nil,
+                 success: 1.0,
+                 trace_id: nil
+               },
+               tags: %ControllerSeries.Tags{
+                 action: nil,
+                 controller: nil,
+                 format: nil,
+                 method: "GET",
+                 status: 200
+               },
+               timestamp: nil
              } ==
                MetricHandler.handle_event(
                  event,

--- a/test/zexbox/metrics/metric_handler_test.exs
+++ b/test/zexbox/metrics/metric_handler_test.exs
@@ -21,6 +21,9 @@ defmodule Zexbox.Metrics.MetricHandlerTest do
           phoenix_format: "html",
           phoenix_controller: :page_controller
         },
+        assigns: %{
+          trace_id: "trace_id"
+        },
         request_path: "/",
         req_headers: [{"referer", "https://www.google.com"}]
       }
@@ -31,7 +34,7 @@ defmodule Zexbox.Metrics.MetricHandlerTest do
     expected = %ControllerSeries{
       fields: %Zexbox.Metrics.ControllerSeries.Fields{
         count: 1,
-        trace_id: "empty_for_now",
+        trace_id: "trace_id",
         duration_ms: 1000,
         http_referer: "https://www.google.com",
         path: "/",


### PR DESCRIPTION
# Description
Currently, when are error occurs in the `MetricHandler.handle_event/4` function the whole process crashes and, more importantly, it looks like it doesn't actually restart. Ultimately we need to ensure that the instream connection is recreated after a crash but for now we'll capture and log the relevant error.

This also makes some of the series metric building more robust and actually provides the ability to attach real trace IDs to our metrics.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (update README)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my changes work
- [x] New and existing unit tests pass locally with my changes
